### PR TITLE
Fixed segfaults

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -66,18 +66,18 @@ int ext2_add_child(struct ext2_fs *f, int parent_inode, int i_no, char* name, in
 				return NULL;
 			}
 			d->rec_len = calc; 		// Resize this entry to it's real size
-			d = (struct ext2_dirent*)((uint32_t) d + d->rec_len);
+			d = (struct ext2_dirent*)((char*) d + d->rec_len);
 			break;
 		}
 		//printf("name %s\n",d->name);
-		d = (struct ext2_dirent*)((uint32_t) d + d->rec_len);
+		d = (struct ext2_dirent*)((char*) d + d->rec_len);
 
 		if (d->rec_len == 0)
 			break;
 	} while(sum < f->block_size);
 
 	/* d is now pointing at a blank entry, right after the resized last entry */
-	d->rec_len 		= f->block_size - ((uint32_t)d - (uint32_t)rootdir_buf->data);
+	d->rec_len 		= f->block_size - ((char*)d - (char*)rootdir_buf->data);
 	d->inode 		= i_no;
 	d->file_type 	= 1;
 	d->name_len 	= strlen(name);
@@ -102,7 +102,7 @@ int ext2_find_child(struct ext2_fs *f, const char* name, int dir_inode) {
 
 	for (int q = 0; q < i->blocks / 2; q++) {
 		buffer* b = buffer_read(f, i->block[q]);
-		memcpy((uint32_t)buf+(q * f->block_size), b->data, f->block_size);
+		memcpy((char*)buf+(q * f->block_size), b->data, f->block_size);
 	}
 
 	struct ext2_dirent* d = (struct ext2_dirent*) buf;
@@ -182,7 +182,7 @@ void ls(struct ext2_fs *f, int inode_num) {
 	for (int q = 0; q < num_blocks; q++) {
 		printf("%d\n", i->block[q]);
 		buffer* b = buffer_read(f, i->block[q]);
-		memcpy((uint32_t)buf + (q*f->block_size), b->data, f->block_size);
+		memcpy((char*)buf + (q*f->block_size), b->data, f->block_size);
 		buffer_free(b);
 	}
 

--- a/ext2.c
+++ b/ext2.c
@@ -167,7 +167,7 @@ int ext2_blockdesc_read(struct ext2_fs *f) {
 	for (int i = 0; i < num_to_read; i++) {
 		int n = EXT2_SUPER + i + ((f->block_size == 1024) ? 1 : 0); 	
 		buffer* b = buffer_read(f, n);
-		memcpy((uint32_t) f->bg + (i*f->block_size), b->data, f->block_size);
+		memcpy(((char*) f->bg) + (i*f->block_size), b->data, f->block_size);
 		buffer_free(b);
 	}
 	return 0;
@@ -183,7 +183,7 @@ int ext2_blockdesc_write(struct ext2_fs *f) {
 	for (int i = 0; i < num_to_read; i++) {
 		int n = EXT2_SUPER + i + ((f->block_size == 1024) ? 1 : 0); 	
 		buffer* b = buffer_read(f, n);
-		memcpy(b->data, (uint32_t) f->bg + (i*f->block_size), f->block_size);
+		memcpy(b->data, (char*) f->bg + (i*f->block_size), f->block_size);
 
 		#ifdef DEBUG
 		printf("Writing to block group desc (block %d)\n", n);

--- a/file.c
+++ b/file.c
@@ -259,13 +259,13 @@ size_t ext2_read_file(struct ext2_fs *f, struct ext2_inode* in, char* buf) {
 		if (i < 12) {
 			blocknum = in->block[i];
 			buffer* b = buffer_read(f, blocknum);
-			memcpy((uint32_t) buf + (i * f->block_size), b->data, f->block_size);
+			memcpy((char*) buf + (i * f->block_size), b->data, f->block_size);
 			buffer_free(b);
 		}
 		if (i > 12) {
 			blocknum = ext2_read_indirect(f, indirect, i-13);
 			buffer* b = buffer_read(f, blocknum);
-			memcpy((uint32_t) buf + ((i-1) * f->block_size), b->data, f->block_size);
+			memcpy((char*) buf + ((i-1) * f->block_size), b->data, f->block_size);
 			buffer_free(b);
 		}
 

--- a/inode.c
+++ b/inode.c
@@ -45,7 +45,7 @@ struct ext2_inode* ext2_read_inode(struct ext2_fs *f, int i) {
 	buffer* b = buffer_read(f, bgd->inode_table+block);
 	struct ext2_inode* in = malloc(INODE_SIZE);
 	/* Switched to memcpy. This may avoid issues for OS level buffer caching. */
-	memcpy(in, ((uint32_t) b->data + (index % (f->block_size/INODE_SIZE))*INODE_SIZE), INODE_SIZE);
+	memcpy(in, ((char*) b->data + (index % (f->block_size/INODE_SIZE))*INODE_SIZE), INODE_SIZE);
 	release_fs(f);
 	return in;
 }
@@ -65,7 +65,7 @@ void ext2_write_inode(struct ext2_fs *f, int inode_num, struct ext2_inode* i) {
 
 	// Not using the inode table was the issue...
 	buffer* b = buffer_read(f, bgd->inode_table+block);
-	memcpy((uint32_t) b->data + offset, i, INODE_SIZE);
+	memcpy((char*) b->data + offset, i, INODE_SIZE);
 	buffer_write(f, b);
 
 	release_fs(f);


### PR DESCRIPTION
When running ext2util on a 64-bit machine (in my case, 64-bit Arch Linux), segfaults occurred often. I determined the cause to be some pointer arithmetic that only works for 32-bit machines. The pointer arithmetic that caused these faults casts a pointer as an `uint32_t` and then adds an offset value to calculate a new pointer. This new pointer is correct on 32-bit systems, but is incorrect for 64-bit systems. I replaced the `uint32_t` cast with a `char*` to fix this.